### PR TITLE
Fix transformer backward collection and add tensor helpers

### DIFF
--- a/Core/Models/AttentionLayer.cs
+++ b/Core/Models/AttentionLayer.cs
@@ -351,14 +351,14 @@ public sealed class AttentionLayer : ILayer
         return outputGrads;
     }
 
-    private float[,] CombineWeightGradients(params float[,][] gradients)
+    private float[,] CombineWeightGradients(params float[][,] gradients)
     {
         // Combine all weight gradients into a single matrix
         int totalSize = gradients.Sum(g => g.Length);
         return new float[1, totalSize]; // Simplified
     }
 
-    private float[] CombineWeights(params float[,][] weights)
+    private float[] CombineWeights(params float[][,] weights)
     {
         return weights.SelectMany(w => w.Flatten()).ToArray();
     }

--- a/Core/Models/TenserExtension.cs
+++ b/Core/Models/TenserExtension.cs
@@ -30,4 +30,43 @@ public static class TensorExtensions
 
         return result;
     }
+
+    /// <summary>
+    /// Flatten a 2D matrix into a 1D array in row-major order
+    /// </summary>
+    public static float[] Flatten(this float[,] matrix)
+    {
+        int rows = matrix.GetLength(0);
+        int cols = matrix.GetLength(1);
+        var result = new float[rows * cols];
+        int index = 0;
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < cols; j++)
+            {
+                result[index++] = matrix[i, j];
+            }
+        }
+        return result;
+    }
+
+    /// <summary>
+    /// Convert a flattened array back into a 2D matrix
+    /// </summary>
+    public static float[,] Unflatten(this float[] data, int rows, int cols)
+    {
+        if (data.Length != rows * cols)
+            throw new ArgumentException($"Array length {data.Length} does not match dimensions [{rows}, {cols}]");
+
+        var result = new float[rows, cols];
+        int index = 0;
+        for (int i = 0; i < rows; i++)
+        {
+            for (int j = 0; j < cols; j++)
+            {
+                result[i, j] = data[index++];
+            }
+        }
+        return result;
+    }
 }

--- a/DataPipeline/Tokenization/CharacterTokenizer.cs
+++ b/DataPipeline/Tokenization/CharacterTokenizer.cs
@@ -16,7 +16,8 @@ public sealed class CharacterTokenizer : ITokenizer
 {
     private readonly Dictionary<char, int> _charToToken = new();
     private readonly Dictionary<int, char> _tokenToChar = new();
-    private readonly Lock _lock = new();
+    // Use a simple object for locking as the standard Monitor lock target
+    private readonly object _lock = new();
     private bool _isFitted = false;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add missing Flatten/Unflatten helpers
- use plain object for tokenizer locking
- expose `BackwardDetailed` on transformer block and use it in model
- fix params signature for weight helpers in attention layer

## Testing
- `dotnet test --no-build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebb569ae88328b3d395a946c73f8d