### PR TITLE
Enable training samples and optional metrics log

### DIFF
--- a/ConsoleApp/TrainShakespeare.cs
+++ b/ConsoleApp/TrainShakespeare.cs
@@ -17,7 +17,8 @@ public static class TrainShakespeare
         try
         {
             // Setup logging
-            var logger = new ConsoleLogger();
+            var logFile = Path.Combine(Path.GetTempPath(), "tinyllm_training.log");
+            var logger = new ConsoleLogger(logFilePath: logFile);
 
             // Configuration
             // Navigate up from bin/Debug/net9.0 to solution root
@@ -82,10 +83,12 @@ public static class TrainShakespeare
                 CheckpointFrequency = 1,
                 ValidationFrequency = 1,
                 SampleGenerationFrequency = 1,
+                SampleTemperature = 0.7f,
                 MaxValidationBatches = 50,
                 EarlyStoppingPatience = 3,
                 RandomSeed = 42,
-                SamplePrompts = new[] { "To be", "Romeo", "What", "The " }
+                SamplePrompts = new[] { "To be", "Romeo", "What", "The " },
+                MetricsCsvEnabled = false
             };
 
             // Initialize model and optimizer

--- a/Infrastructure/Logging/ConsoleLogger.cs
+++ b/Infrastructure/Logging/ConsoleLogger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -8,13 +9,23 @@ namespace Infrastructure.Logging;
 /// <summary>
 /// Console logger implementation
 /// </summary>
-public class ConsoleLogger : ILogger
+public class ConsoleLogger : ILogger, IDisposable
 {
     private readonly string _name;
+    private readonly StreamWriter? _logWriter;
 
-    public ConsoleLogger(string name = "")
+    public ConsoleLogger(string name = "", string? logFilePath = null)
     {
         _name = name;
+
+        if (!string.IsNullOrWhiteSpace(logFilePath))
+        {
+            var directory = Path.GetDirectoryName(logFilePath);
+            if (!string.IsNullOrEmpty(directory))
+                Directory.CreateDirectory(directory);
+            _logWriter = new StreamWriter(logFilePath, append: false);
+            _logWriter.AutoFlush = true;
+        }
     }
 
     public void LogInformation(string message, params object[] args)
@@ -70,7 +81,17 @@ public class ConsoleLogger : ILogger
             message = result;
         }
 
-        Console.WriteLine($"[{timestamp}] [{level}] {prefix}{message}");
+        var formatted = $"[{timestamp}] [{level}] {prefix}{message}";
+        Console.WriteLine(formatted);
+        if (_logWriter != null)
+        {
+            _logWriter.WriteLine(formatted);
+        }
+    }
+
+    public void Dispose()
+    {
+        _logWriter?.Dispose();
     }
 }
 

--- a/Infrastructure/Training/MetricsLogger.cs
+++ b/Infrastructure/Training/MetricsLogger.cs
@@ -22,13 +22,15 @@ public class MetricsLogger
         // Create output directory if it doesn't exist
         Directory.CreateDirectory(config.OutputDirectory);
 
-        // Setup metrics file
-        _outputPath = Path.Combine(config.OutputDirectory, "training_metrics.csv");
-        _fileWriter = new StreamWriter(_outputPath, append: false);
-        _fileWriter.WriteLine("step,epoch,loss,learning_rate,gradient_norm,validation_loss,validation_perplexity");
-        _fileWriter.Flush();
+        if (config.MetricsCsvEnabled)
+        {
+            _outputPath = Path.Combine(config.OutputDirectory, "training_metrics.csv");
+            _fileWriter = new StreamWriter(_outputPath, append: false);
+            _fileWriter.WriteLine("step,epoch,loss,learning_rate,gradient_norm,validation_loss,validation_perplexity");
+            _fileWriter.Flush();
 
-        _logger.LogInformation("Metrics will be saved to: {Path}", _outputPath);
+            _logger.LogInformation("Metrics will be saved to: {Path}", _outputPath);
+        }
     }
 
     public Task LogStepAsync(int step, TrainingStepResult result, CancellationToken cancellationToken)

--- a/Infrastructure/Training/TrainingConfiguration.cs
+++ b/Infrastructure/Training/TrainingConfiguration.cs
@@ -31,6 +31,7 @@ public class TrainingConfiguration
     public int CheckpointFrequency { get; init; } = 1;
     public int ValidationFrequency { get; init; } = 1;
     public int SampleGenerationFrequency { get; init; } = 1;
+    public float SampleTemperature { get; init; } = 0.7f;
     public int MaxValidationBatches { get; init; } = 100;
 
     // Early stopping
@@ -40,6 +41,7 @@ public class TrainingConfiguration
     public int? RandomSeed { get; init; } = 42;
     public string? ResumeFromCheckpoint { get; init; }
     public string[] SamplePrompts { get; init; } = Array.Empty<string>();
+    public bool MetricsCsvEnabled { get; init; } = false;
 
     public int GetTotalSteps()
     {

--- a/Infrastructure/Training/TrainingLoop.cs
+++ b/Infrastructure/Training/TrainingLoop.cs
@@ -365,6 +365,7 @@ public sealed class TrainingLoop
         var tokens = tokenizer.Encode(prompt.AsSpan()).ToList();
         var random = new Random();
 
+        var temperature = context.Configuration.SampleTemperature;
         for (int i = 0; i < 50; i++) // Generate up to 50 tokens
         {
             if (cancellationToken.IsCancellationRequested)
@@ -375,7 +376,7 @@ public sealed class TrainingLoop
 
             // Simple temperature sampling
             var probabilities = new float[logits.Length];
-            var scaledLogits = logits.Select(l => l / 0.8f).ToArray(); // Temperature = 0.8
+            var scaledLogits = logits.Select(l => l / temperature).ToArray();
             NumericalFunctions.Softmax(scaledLogits, probabilities);
 
             var nextToken = SampleFromDistribution(probabilities, random);

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # TinyLLM
+
+TinyLLM is a minimal educational language model implementation in C#. The console application provides a simple workflow to train a character-level model on Shakespeare text.
+
+## Training Example
+
+Run the console application and choose the training option. Logs will be written to `tinyllm_training.log` and small text samples are generated after every epoch using the configured temperature (default `0.7`). Metrics CSV logging is behind a feature flag and disabled by default.
+
+Training can take a long time, especially for large datasets. The provided Shakespeare dataset contains about one million characters which results in tens of thousands of batches per epoch.


### PR DESCRIPTION
## Summary
- generate text samples using a configurable temperature
- write console log to `tinyllm_training.log`
- add feature flag to disable `training_metrics.csv`
- document training behaviour and long epochs

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb42a36e08328b6ac0cd2bd31a5f9